### PR TITLE
Update README to use gpm-local

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,12 @@ Install dependencies by running:
 
 ### One time only
 
-Tell gpm to link project's subpackages with `gpm-local`:
+Tell gpm to link this project into the `.godeps` dir with `gpm-local`:
 
     $ gpm local name github.com/crowdint/gopher-spree-api
 
-This will allow us to work with uncommitted subpackage changes, as this
-will link every subpackage to be found inside the `.godeps` directory
-under this project's path.
+This will allow us to find this projects subpackages in the current
+$GOPATH
 
 ### Adding new dependencies
 


### PR DESCRIPTION
After implementing gpm and gvp, if you run:

```
$ go test ./...
```

You'd get the following errors:

```
configs/spree/config.go:9:2: cannot find package "github.com/crowdint/gopher-spree-api/configs" in any of:
        /usr/local/Cellar/go/1.4.2/libexec/src/github.com/crowdint/gopher-spree-api/configs (from $GOROOT)
        /Users/joiggama/.go/src/github.com/crowdint/gopher-spree-api/.godeps/src/github.com/crowdint/gopher-spree-api/configs (from $GOPATH)
        /Users/joiggama/.go/src/github.com/crowdint/gopher-spree-api/src/github.com/crowdint/gopher-spree-api/configs
domain/json/variant.go:6:2: cannot find package "github.com/crowdint/gopher-spree-api/configs/spree" in any of:
        /usr/local/Cellar/go/1.4.2/libexec/src/github.com/crowdint/gopher-spree-api/configs/spree (from $GOROOT)
        /Users/joiggama/.go/src/github.com/crowdint/gopher-spree-api/.godeps/src/github.com/crowdint/gopher-spree-api/configs/spree (from $GOPATH)
        /Users/joiggama/.go/src/github.com/crowdint/gopher-spree-api/src/github.com/crowdint/gopher-spree-api/configs/spree
domain/json/variant.go:7:2: cannot find package "github.com/crowdint/gopher-spree-api/domain/models" in any of:
        /usr/local/Cellar/go/1.4.2/libexec/src/github.com/crowdint/gopher-spree-api/domain/models (from $GOROOT)
        /Users/joiggama/.go/src/github.com/crowdint/gopher-spree-api/.godeps/src/github.com/crowdint/gopher-spree-api/domain/models (from $GOPATH)
        /Users/joiggama/.go/src/github.com/crowdint/gopher-spree-api/src/github.com/crowdint/gopher-spree-api/domain/models
interfaces/repositories/adjustment.go:4:2: cannot find package "github.com/crowdint/gopher-spree-api/domain/json" in any of:
        /usr/local/Cellar/go/1.4.2/libexec/src/github.com/crowdint/gopher-spree-api/domain/json (from $GOROOT)
        /Users/joiggama/.go/src/github.com/crowdint/gopher-spree-api/.godeps/src/github.com/crowdint/gopher-spree-api/domain/json (from $GOPATH)
        /Users/joiggama/.go/src/github.com/crowdint/gopher-spree-api/src/github.com/crowdint/gopher-spree-api/domain/json
interfaces/repositories/inventory_unit.go:5:2: cannot find package "github.com/crowdint/gopher-spree-api/utils" in any of:
        /usr/local/Cellar/go/1.4.2/libexec/src/github.com/crowdint/gopher-spree-api/utils (from $GOROOT)
        /Users/joiggama/.go/src/github.com/crowdint/gopher-spree-api/.godeps/src/github.com/crowdint/gopher-spree-api/utils (from $GOPATH)
        /Users/joiggama/.go/src/github.com/crowdint/gopher-spree-api/src/github.com/crowdint/gopher-spree-api/utils
interfaces/web/main.go:6:2: cannot find package "github.com/crowdint/gopher-spree-api/interfaces/repositories" in any of:
        /usr/local/Cellar/go/1.4.2/libexec/src/github.com/crowdint/gopher-spree-api/interfaces/repositories (from $GOROOT)
        /Users/joiggama/.go/src/github.com/crowdint/gopher-spree-api/.godeps/src/github.com/crowdint/gopher-spree-api/interfaces/repositories (from $GOPATH)
        /Users/joiggama/.go/src/github.com/crowdint/gopher-spree-api/src/github.com/crowdint/gopher-spree-api/interfaces/repositories
interfaces/web/main.go:7:2: cannot find package "github.com/crowdint/gopher-spree-api/interfaces/web/api" in any of:
        /usr/local/Cellar/go/1.4.2/libexec/src/github.com/crowdint/gopher-spree-api/interfaces/web/api (from $GOROOT)
        /Users/joiggama/.go/src/github.com/crowdint/gopher-spree-api/.godeps/src/github.com/crowdint/gopher-spree-api/interfaces/web/api (from $GOPATH)
        /Users/joiggama/.go/src/github.com/crowdint/gopher-spree-api/src/github.com/crowdint/gopher-spree-api/interfaces/web/api
interfaces/web/api/orders.go:8:2: cannot find package "github.com/crowdint/gopher-spree-api/usecases/json" in any of:
        /usr/local/Cellar/go/1.4.2/libexec/src/github.com/crowdint/gopher-spree-api/usecases/json (from $GOROOT)
        /Users/joiggama/.go/src/github.com/crowdint/gopher-spree-api/.godeps/src/github.com/crowdint/gopher-spree-api/usecases/json (from $GOPATH)
        /Users/joiggama/.go/src/github.com/crowdint/gopher-spree-api/src/github.com/crowdint/gopher-spree-api/usecases/json
```

Project's subpackages where not found because the $GOPATH does not include these subpackages.

This PR is to update the README instructions to do a ONE TIME only operation to fix it.
