### PR TITLE
Update README, let's forget about gvp

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ To start Memcached Server
 
     $ memcached -vv
 
-### Istalling Elastic (Elastic Search)
-Follow the instructions in https://www.elastic.co/guide/en/elasticsearch/reference/current/_installation.html
+### Install Elastic Search
+
+Follow the instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/_installation.html).
 
 ## Workflow
 


### PR DESCRIPTION
So, it turned out that the usage of gvp + gpm-local has been a PITA, especially for this project that has subpackages.
From time to time, I've seen errors caused by vendored subpackages being checked out at a previous state, differing from their actual source code.

Note that the packages I mention are our project's subpackages, using gvp involves vendoring our own subpackages..., mindblowing, right?

From now on, we can rely on bare `gpm` without the need of `gvp` and `gpm-local`, the reason is that if we already have some packages installed, gpm only makes sure to check them out in the version we require.
