### PR TITLE
Add configuration for X-Domain Policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ SPREE_URL             = http://localhost:5100                              # Hos
 SPREE_ASSET_PATH      = ":host/spree/products/:asset_id/:style/:filename"  # Assets default path
 SPREE_ASSET_HOST      = ""                                                 # Assets host
 SPREE_DEFAULT_STYLES  = "mini,small,product,large"                         # Assets default styles
-```
 
 # Cross Domain Policy
-X_ORIGIN              = '*'                                                # X-Domain origin header
+X_ORIGIN              = ''                                                 # X-Domain origin header. By default is not allowed.
 X_METHODS             = '*'                                                # X-Domain methods header
+```
 
 ## Build
 

--- a/configs/config.go
+++ b/configs/config.go
@@ -64,7 +64,7 @@ var defaultSettings = map[string]string{
 	ES_PRODUCT_TYPE:           getEnvOrDefault(ES_PRODUCT_TYPE, "product"),
 
 	//Access Control
-	X_ORIGIN:  getEnvOrDefault(X_ORIGIN, "*"),
+	X_ORIGIN:  getEnvOrDefault(X_ORIGIN, ""),
 	X_METHODS: getEnvOrDefault(X_METHODS, "*"),
 }
 

--- a/interfaces/web/api/proxy.go
+++ b/interfaces/web/api/proxy.go
@@ -27,8 +27,7 @@ func init() {
 
 func Proxy() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		c.Writer.Header().Set("Access-Control-Allow-Origin", configs.Get(configs.X_ORIGIN))
-		c.Writer.Header().Set("Access-Control-Allow-Methods", configs.Get(configs.X_METHODS))
+		setOriginPolicyHeaders(c)
 		if shouldRedirectToOrigin(c) {
 			c.Abort()
 			proxy.ServeHTTP(c.Writer, c.Request)
@@ -57,4 +56,13 @@ func isMissingRoute(method string, url *url.URL) bool {
 	}
 
 	return true
+}
+
+func setOriginPolicyHeaders(c *gin.Context) {
+	originConfig := configs.Get(configs.X_ORIGIN)
+	if originConfig != "" {
+		c.Writer.Header().Set("Access-Control-Allow-Origin", configs.Get(configs.X_ORIGIN))
+		c.Writer.Header().Set("Access-Control-Allow-Methods", configs.Get(configs.X_METHODS))
+	}
+
 }


### PR DESCRIPTION
- Include Access Control headers
- Add default config for:
  - Access-Control-Allow-Origin: *
  - Access-Control-Allow-Methods: *
